### PR TITLE
Locate files and directories based on file globs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,10 +16,12 @@ are necessary for the build, but are not required at runtime. There may
 also be installable build dependencies that are not runtime
 dependencies.
 
-In our case, a complex front-end build involves significant CSS, JS and
-image assets, along with a large installation of node modules, all of
+Use cases include:
+
+* Large installation of node modules, all of
 which are used only for building the production assets, but then remain
 part of the slug.
+* Test and spec folders in Gem dependencies stored in vendor/bundle
 
 ## Usage
 
@@ -36,14 +38,11 @@ https://github.com/heroku/heroku-buildpack-ruby
 https://github.com/Lostmyname/heroku-post-build-clean-buildpack
 ```
 
-The `.slug-post-clean` file supports single-file and single-directory
-declarations only, e.g.:
+The `.slug-post-clean` file supports file globs (including file/directory names with whitespace, but NOT new lines) e.g.:
 
 ```
+vendor/bundle/ruby/*/gems/sass-*/test
 some_huge_file.psd
 some/nested/directory
 why_does_this_app_even_contain_a.tiff
 ```
-
-I might expand it to support file globs, but for the moment it's not
-necessary and the testing implications give me the willies.

--- a/bin/compile
+++ b/bin/compile
@@ -1,32 +1,79 @@
 #!/usr/bin/env bash
+#
+# Find and delete all files/directories matching specified globs
+# Globs are separated by newlines in .slug-post-clean located in the build directory's root
+# This is useful for deleting files created after Heroku's built-in cleanup process
+# based on .slugignore, e.g. files/dirs in installed dependency folders
 
 set -euo pipefail
 
-readonly BUILD_DIR=$1
-readonly CLEAN_FILES=.slug-post-clean
+readonly BUILDPACK_DIR=$(cd $(dirname $0); cd ..; pwd)
 
-if [[ ! -n "${BUILD_DIR}" ]]; then
-  echo "No build directory specified - exiting"
-  exit 1
-fi
+# Common helper functions
+source $BUILDPACK_DIR/bin/util/common.sh
+
+readonly CLEAN_FILES=.slug-post-clean
+readonly BUILD_DIR=$1
 
 cd ${BUILD_DIR}
 
-if [[ ! -f "${CLEAN_FILES}" ]]; then
-  echo "Could not find .slug-post-clean file - exiting"
-  exit 1
-fi
+#######################################
+# Locate files/dirs in PWD matching globs in $CLEAN_FILES
+# Globals:
+#   CLEAN_FILES
+#   IFS
+#   fileArray
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+findMatchingFiles()
+{
+  local globArray oldIFS
 
-while read file; do
-  [[ ! -n "${file}" ]] && continue
+  [[ -f ${CLEAN_FILES} ]] || error_exit "Could not find file ${CLEAN_FILES}"
 
-  if [[ -f "${file}" ]]; then
-    echo "Removing file ${file} from slug"
-    rm -f ${file}
-  elif [[ -d "${file}" ]]; then
-    echo "Removing directory ${file} from slug"
-    rm -rf ${file}
-  else
-    echo "Location ${file} not found - ignoring"
-  fi
-done <${CLEAN_FILES}
+  status "Finding all matching files and directories in ${CLEAN_FILES}"
+
+  # Temporarily change IFS from all whitespace to newline only
+  oldIFS=$IFS
+  IFS=$'\n'
+
+  # Read globs to an array
+  mapfile -t globArray < ${CLEAN_FILES}
+
+  # Recurse through all matching files/dirs and populate a new array with the result
+  fileArray=()
+  while IFS= read -r -d $'\0'; do
+    fileArray+=("$REPLY")
+  done < <(find ${globArray[*]} -print0)
+
+  # Restore IFS
+  IFS=$oldIFS
+}
+
+#######################################
+# Delete all matching files and directories
+# Globals:
+#   fileArray
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+runRemoval()
+{
+  [[ -z ${fileArray+x} ]] && error_exit "No files or directories to remove from slug"
+
+  status "Removing all matching files and directories from slug"
+  local fileOrDir
+  for fileOrDir in "${fileArray[@]}"; do
+    rm -rf "$fileOrDir"
+    echo "Removed ${fileOrDir} from slug"
+  done
+}
+
+# Run!
+findMatchingFiles
+runRemoval

--- a/bin/detect
+++ b/bin/detect
@@ -2,17 +2,11 @@
 
 set -euo pipefail
 
-readonly BUILD_DIR=$1
-
-if [[ ! -n "${BUILD_DIR}" ]]; then
-  echo "No build directory specified - exiting"
-  exit 1
-fi
-
-if [[ ! -f "${BUILD_DIR}/.slug-post-clean" ]]; then
+# This pack is valid for apps with a .slug-post-clean in the root
+if [ -f $1/.slug-post-clean ]; then
+  echo "POST BUILD CLEAN"
+  exit 0
+else
   echo "Could not find .slug-post-clean file - exiting"
   exit 1
 fi
-
-echo "POST BUILD CLEAN"
-exit 0

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Common helper functions
+
+error_exit()
+{
+  echo "$1 - exiting" 1>&2
+  exit 1
+}
+
+status() {
+  echo "=== $* ==="
+}


### PR DESCRIPTION
# What

In order to reduce slug size, we would like to clean up folders and files in Gem dependencies. Unfortunately, these are created after the process that uses `.slugignore` during Heroku's [slug compilation process](https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore).

This existing buildpack supports cleanup of files post-process, which is great! However, since dependency folders are versioned (e.g. `vendor/bundle/ruby/2.2.0/nokogiri-1.6.8.1/test`) I needed to enable support for specifying file globs in `.slug-post-clean` file in order to use this effectively.
## Test Results
### Example `.slug-post-clean` file:

```
vendor/bundle/ruby/*/gems/sass-*/test
vendor/bundle/ruby/*/gems/nokogiri-*/test
```
### Slug size

Without buildpack: 27.9M
Using buildpack: 27.6M
### Snippet from example app build log:

```
...
-----> POST BUILD CLEAN app detected
=== Finding all matching files and directories in .slug-post-clean ===
=== Removing all matching files and directories from slug ===
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/mock_importer.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/encoding_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/script_conversion_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/value_helpers_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/cache_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/parent_ref.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_charset_1_8.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/filename_fn.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/mixins.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/if.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/units.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/alt.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_content.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/complex.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/compact.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/nested.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/scss_importee.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/cached_import_option.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_charset_ibm866.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/compressed.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/multiline.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/scss_import.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/script.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_charset.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/expanded.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir/nested_subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir/nested_subdir/nested_subdir.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir/subdir.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/basic.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/warn_imported.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/line_numbers.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/warn.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/options.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/compiler_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/css2sass_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/exec_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates/more_import.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates/_more_partial.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates/more1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/data from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/data/hsl-rgb.txt from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/test_helper.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/logger_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/conversion_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util/subset_map_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util/multibyte_string_scanner_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util/normalized_map_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/superselector_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/plugin_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/extend_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/engine_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results/more1.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results/more_import.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results/more1_with_line_comments.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/scss_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/test_helper.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/css_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/rx_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/fixtures from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/fixtures/test_staleness_check_across_importers.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/fixtures/test_staleness_check_across_importers.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/source_map_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/css_variable_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/callbacks_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/functions_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/same_name_different_ext.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_double_import_loop2.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/alt.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/warn_imported.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/units.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/mixin_bork.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/basic.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork4.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_filename_fn_import.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/line_numbers.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/cached_import_option.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_import.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/double_import_loop1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/importee.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/expanded.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/scss_import.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/parent_ref.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/warn.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/filename_fn.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_same_name_different_partiality.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/script.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/compact.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_charset.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork2.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/same_name_different_ext.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_imported_charset_ibm866.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_imported_content.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_cached_import_option_partial.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/same_name_different_partiality.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/multiline.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_charset_1_8.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_partial.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork4.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/scss_importee.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork5.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/importee.less from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/single_import_loop.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/import_up2.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/import_up1.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/subdir.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/nested_subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/nested_subdir/_nested_partial.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/nested_subdir/nested_subdir.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork2.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_charset_ibm866.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork3.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/complex.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_mixin_bork.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/if.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/mixins.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_imported_charset_utf8.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_content.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/options.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork3.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/compressed.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/script_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/importer_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/test_helper.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass-spec.yml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_node.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_builder.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax/test_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax/test_parser_context.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax/test_push_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_element_description.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_document.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_node_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_document_fragment.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_document_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_named_characters.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_soap4r_sax.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_css_cache.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_convert_xpath.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_nokogiri.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_element_decl.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_reader.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_xpath.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_dtd.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_c14n.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_builder.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_entity_decl.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax/test_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax/test_parser_context.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax/test_push_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_comment.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_attr.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_document.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_cdata.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_reader_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_unparented_node.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_xinclude.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_document_fragment.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_inheritance.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_entity_reference.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_namespace.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_dtd_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_element_content.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_set.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_syntax_error.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_parse_options.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_attributes.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/node from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/node/test_subclass.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/node/test_save_options.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_reparenting.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_schema.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_processing_instruction.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_document_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_text.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_relax_ng.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_attribute_decl.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/decorators from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/decorators/test_slop.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_cloned_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_preservation.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_aliased_default.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_builder_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_created_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_additional_namespaces_in_builder_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_parsed_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_memory_leak.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/encoding.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/slow-xpath.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/encoding.xhtml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/exslt.xslt from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/exslt.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/shift_jis.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/atom.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/address_book.rlx from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/noencoding.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/staff.dtd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/2ch.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url/document.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url/document.dtd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url/bar.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/bar from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/bar/bar.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/xinclude.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/dont_hurt_em_why.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/snuggles.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/foo from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/foo/foo.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/to_be_xincluded.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/tlm.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/GH_1042.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/staff.xslt from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/address_book.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/bogus.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/saml20assertion_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/saml20protocol_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/xenc_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/xmldsig_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/metacharset.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/po.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/po.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/staff.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/valid_bar.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/shift_jis_no_charset.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/namespace_pressure_test.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/shift_jis.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_nthiness.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_tokenizer.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_xpath_visitor.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xslt from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xslt/test_exception_handling.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xslt/test_custom_functions.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_xslt_transforms.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_encoding_handler.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/helper.rb from slug
-----> Discovering process types
       Procfile declares types     -> (none)
       Default types for buildpack -> console, rake, web, worker
-----> Compressing...
       Done: 27.6M
...
```
