### PR TITLE
Reduce amount of logs during build. Only display globs and total numb…

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ findMatchingFiles()
 
   [[ -f ${CLEAN_FILES} ]] || error_exit "Could not find file ${CLEAN_FILES}"
 
-  status "Finding all matching files and directories in ${CLEAN_FILES}"
+  status "Finding all files and directories from ${CLEAN_FILES} matching:"
 
   # Temporarily change IFS from all whitespace to newline only
   oldIFS=$IFS
@@ -42,6 +42,11 @@ findMatchingFiles()
 
   # Read globs to an array
   mapfile -t globArray < ${CLEAN_FILES}
+
+  # Output globs
+  printf '%s\n' ${globArray[*]}
+
+  status "Matches not found:"
 
   # Recurse through all matching files/dirs and populate a new array with the result
   fileArray=()
@@ -68,10 +73,12 @@ runRemoval()
 
   status "Removing all matching files and directories from slug"
   local fileOrDir
+
   for fileOrDir in "${fileArray[@]}"; do
     rm -rf "$fileOrDir"
-    echo "Removed ${fileOrDir} from slug"
   done
+
+  echo "Successfully cleaned ${#fileArray[@]} files/directories from slug"
 }
 
 # Run!


### PR DESCRIPTION
# What

The output in our Heroku builds is too chatty, and can be frustrating on slower browsers. This reduces the amount of logs during build; only displaying globs and total number of files/directories deleted.
## Test Results
### Log snippet now:

```
...
-----> POST BUILD CLEAN app detected
=== Finding all files and directories from .slug-post-clean matching: ===
vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test
vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test
a_non_existent_folder
=== Matches not found: ===
find: `a_non_existent_folder': No such file or directory
=== Removing all matching files and directories from slug ===
Successfully cleaned 263 files/directories from slug
-----> Discovering process types
       Procfile declares types     -> (none)
       Default types for buildpack -> console, rake, web, worker
-----> Compressing...
       Done: 27.6M
...
```
### Log snippet before:

```
...
-----> POST BUILD CLEAN app detected
=== Finding all matching files and directories in .slug-post-clean ===
=== Removing all matching files and directories from slug ===
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/mock_importer.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/encoding_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/script_conversion_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/value_helpers_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/cache_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/parent_ref.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_charset_1_8.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/filename_fn.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/mixins.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/if.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/units.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/alt.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_content.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/complex.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/compact.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/nested.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/scss_importee.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/cached_import_option.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_charset_ibm866.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/compressed.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/multiline.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/scss_import.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/script.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import_charset.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/expanded.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir/nested_subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir/nested_subdir/nested_subdir.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/subdir/subdir.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/basic.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/warn_imported.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/line_numbers.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/import.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/warn.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/results/options.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/compiler_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/css2sass_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/exec_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates/more_import.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates/_more_partial.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_templates/more1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/data from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/data/hsl-rgb.txt from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/test_helper.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/logger_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/conversion_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util/subset_map_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util/multibyte_string_scanner_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util/normalized_map_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/superselector_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/plugin_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/extend_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/engine_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results/more1.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results/more_import.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/more_results/more1_with_line_comments.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/scss_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/test_helper.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/css_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/scss/rx_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/fixtures from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/fixtures/test_staleness_check_across_importers.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/fixtures/test_staleness_check_across_importers.css from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/source_map_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/css_variable_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/callbacks_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/functions_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/same_name_different_ext.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_double_import_loop2.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/alt.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/warn_imported.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/units.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/mixin_bork.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/basic.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork4.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_filename_fn_import.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/line_numbers.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/cached_import_option.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_import.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/double_import_loop1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/importee.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/expanded.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/scss_import.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/parent_ref.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/warn.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/filename_fn.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_same_name_different_partiality.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/script.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/compact.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_charset.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork2.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork1.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/same_name_different_ext.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_imported_charset_ibm866.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_imported_content.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_cached_import_option_partial.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/same_name_different_partiality.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/multiline.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_charset_1_8.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_partial.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork4.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/scss_importee.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork5.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/importee.less from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/single_import_loop.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/import_up2.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/import_up1.scss from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/subdir.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/nested_subdir from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/nested_subdir/_nested_partial.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/subdir/nested_subdir/nested_subdir.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork2.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_charset_ibm866.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/bork3.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/complex.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_mixin_bork.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/if.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/mixins.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/_imported_charset_utf8.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/import_content.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/options.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/nested_bork3.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/templates/compressed.sass from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/script_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/util_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass/importer_test.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/test_helper.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/sass-3.4.22/test/sass-spec.yml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_node.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_builder.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax/test_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax/test_parser_context.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/sax/test_push_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_element_description.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_document.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_node_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_document_fragment.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_document_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/html/test_named_characters.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_soap4r_sax.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_css_cache.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_convert_xpath.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_nokogiri.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_element_decl.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_reader.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_xpath.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_dtd.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_c14n.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_builder.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_entity_decl.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax/test_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax/test_parser_context.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/sax/test_push_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_comment.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_attr.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_document.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_cdata.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_reader_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_unparented_node.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_xinclude.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_document_fragment.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_inheritance.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_entity_reference.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_namespace.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_dtd_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_element_content.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_set.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_syntax_error.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_parse_options.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_attributes.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/node from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/node/test_subclass.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/node/test_save_options.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_node_reparenting.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_schema.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_processing_instruction.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_document_encoding.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_text.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_relax_ng.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xml/test_attribute_decl.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/decorators from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/decorators/test_slop.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_cloned_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_preservation.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_aliased_default.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_builder_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_created_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_additional_namespaces_in_builder_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/namespaces/test_namespaces_in_parsed_doc.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_memory_leak.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/encoding.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/slow-xpath.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/encoding.xhtml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/exslt.xslt from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/exslt.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/shift_jis.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/atom.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/address_book.rlx from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/noencoding.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/staff.dtd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/2ch.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url/document.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url/document.dtd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/test_document_url/bar.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/bar from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/bar/bar.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/xinclude.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/dont_hurt_em_why.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/snuggles.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/foo from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/foo/foo.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/to_be_xincluded.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/tlm.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/GH_1042.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/staff.xslt from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/address_book.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/bogus.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/saml20assertion_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/saml20protocol_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/xenc_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/saml/xmldsig_schema.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/metacharset.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/po.xsd from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/po.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/staff.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/valid_bar.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/shift_jis_no_charset.html from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/namespace_pressure_test.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/files/shift_jis.xml from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_nthiness.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_tokenizer.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_parser.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/css/test_xpath_visitor.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xslt from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xslt/test_exception_handling.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/xslt/test_custom_functions.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_xslt_transforms.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/test_encoding_handler.rb from slug
Removed vendor/bundle/ruby/2.2.0/gems/nokogiri-1.6.8.1/test/helper.rb from slug
-----> Discovering process types
       Procfile declares types     -> (none)
       Default types for buildpack -> console, rake, web, worker
-----> Compressing...
       Done: 27.6M
...
```
